### PR TITLE
Font line height issue connected to jss-expand

### DIFF
--- a/src/defaultUnits.js
+++ b/src/defaultUnits.js
@@ -40,6 +40,7 @@ export default {
   'column-rule-width': 'px',
   'column-width': 'px',
   'flex-basis': 'px',
+  'font-line-height': 'px', // Not existing property. Used to avoid issues with jss-expand intergration
   'font-size': 'px',
   'font-size-delta': 'px',
   height: 'px',


### PR DESCRIPTION
Just a fix `line-height` support inside custom objects in jss-expand connected to https://github.com/cssinjs/jss-expand/pull/13 and described in https://github.com/cssinjs/jss/issues/344 

Why:
Considering config like this:
`````````````````````````````````js
export const customPropObj = {
  border: {
    radius: 'border-radius'
  },
  background: {
    size: 'background-size'
  },
  font: {
    style: 'font-style',
    variant: 'font-variant',
    weight: 'font-weight',
    stretch: 'font-stretch',
    size: 'font-size',
    family: 'font-family',
    lineHeight: 'line-height', // <-- This
    'line-height': 'line-height' // <-- And this
  }
}
`````````````````````````````````
and code:
`````````````````````````````````js
    var jss = jss.create();
    jss.use(jssDefaultUnit.default());
    jss.use(jssExpand.default());
    var sheet = jss.createStyleSheet({
        a: {
          font: {
            style: 'italic',
            variant: 'small-caps',
            weight: 'bold',
            size: 15,
            'line-height': 5, // <-- Look here
            family: 'Arial, Sans-serif'
          }
        },
    });
`````````````````````````````````
and output
`````````````````````````````````css
.a-2542040728 {
  font-style: italic;
  font-variant: small-caps;
  font-weight: bold;
  font-size: 15px;
  font-family: Arial, Sans-serif;
  line-height: 5; /* <-- jss-default-unit ignores this */
}
`````````````````````````````````
