### PR TITLE
[jss-expand] array syntax. Add box shadow support

### DIFF
--- a/src/defaultUnits.js
+++ b/src/defaultUnits.js
@@ -31,6 +31,7 @@ export default {
   'border-start-width': 'px',
   'border-vertical-spacing': 'px',
   bottom: 'px',
+  'box-shadow': 'px',
   'box-shadow-x': 'px', // Not existing property. Used to avoid issues with jss-expand intergration
   'box-shadow-y': 'px', // Not existing property. Used to avoid issues with jss-expand intergration
   'box-shadow-blur': 'px', // Not existing property. Used to avoid issues with jss-expand intergration


### PR DESCRIPTION
Solves situation box-shadow default units issue connected with jss-expand.
Like this:
``````````````````````````js
a: {
  border: [15, 'solid', 'red'],
  'box-shadow': [
    [0, 0, 0, 10, 'blue'],
    [0, 0, 0, 15, 'green']
  ]
},
``````````````````````````
Was discussed here https://github.com/cssinjs/repl/pull/2#issuecomment-265274800